### PR TITLE
Update Terraform tags syntax to new format

### DIFF
--- a/cluster/eks-worker-nodes.tf
+++ b/cluster/eks-worker-nodes.tf
@@ -58,12 +58,10 @@ resource "aws_security_group" "demo-node" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = "${
-    map(
-     "Name", "terraform-eks-demo-node",
-     "kubernetes.io/cluster/${var.cluster-name}", "owned",
-    )
-  }"
+  tags = {
+    Name = "terraform-eks-demo-node"
+    "kubernetes.io/cluster/${var.cluster-name}" = "owned"
+  }
 }
 
 resource "aws_security_group_rule" "demo-node-ingress-self" {

--- a/cluster/vpc.tf
+++ b/cluster/vpc.tf
@@ -9,12 +9,10 @@
 resource "aws_vpc" "demo" {
   cidr_block = "10.0.0.0/16"
 
-  tags = "${
-    map(
-     "Name", "terraform-eks-demo-node",
-     "kubernetes.io/cluster/${var.cluster-name}", "shared",
-    )
-  }"
+  tags = {
+    Name = "terraform-eks-demo-node"
+    "kubernetes.io/cluster/${var.cluster-name}" = "shared"
+  }
 }
 
 resource "aws_subnet" "demo" {


### PR DESCRIPTION
This PR updates the tags syntax in multiple Terraform files to use the newer object notation instead of the deprecated `map()` function. Changes include:

- Updated `aws_security_group` tags in `eks-cluster.tf` to use `tags = {}`
- Replaced `map()` function with object notation in `eks-worker-nodes.tf`
- Updated VPC resource tags in `vpc.tf` to use new syntax for:
  - AWS VPC
  - Subnets
  - Internet Gateway

These changes maintain the same tag values while adopting the current Terraform syntax for tag definitions.