### PR TITLE
Update Terraform tags syntax to new format

### DIFF
--- a/cluster/vpc.tf
+++ b/cluster/vpc.tf
@@ -22,12 +22,10 @@ resource "aws_subnet" "demo" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = "${aws_vpc.demo.id}"
 
-  tags = "${
-    map(
-     "Name", "terraform-eks-demo-node",
-     "kubernetes.io/cluster/${var.cluster-name}", "shared",
-    )
-  }"
+  tags = {
+    Name = "terraform-eks-demo-node"
+    "kubernetes.io/cluster/${var.cluster-name}" = "shared"
+  }
 }
 
 resource "aws_internet_gateway" "demo" {


### PR DESCRIPTION
This PR updates the tags syntax in multiple Terraform files to use the new HCL format. Changes include:

- Updated `aws_security_group "demo-cluster"` tags syntax
- Changed `aws_security_group "demo-node"` tags from map interpolation to direct assignment
- Updated `aws_subnet "demo"` tags from map interpolation to direct assignment
- Fixed `aws_internet_gateway "demo"` tags syntax

These changes align the configuration with current Terraform best practices and remove deprecated syntax.