### PR TITLE
Update Terraform tags syntax to HCL2 format

### DIFF
--- a/cluster/vpc.tf
+++ b/cluster/vpc.tf
@@ -22,12 +22,10 @@ resource "aws_subnet" "demo" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = "${aws_vpc.demo.id}"
 
-  tags = "${
-    map(
-     "Name", "terraform-eks-demo-node",
-     "kubernetes.io/cluster/${var.cluster-name}", "shared",
-    )
-  }"
+  tags = {
+    Name = "terraform-eks-demo-node"
+    "kubernetes.io/cluster/${var.cluster-name}" = "shared"
+  }
 }
 
 resource "aws_internet_gateway" "demo" {


### PR DESCRIPTION
This PR updates the tags syntax in multiple Terraform files to use the newer HCL2 format. Changes include:

- Updated `aws_security_group` tags in eks-cluster.tf
- Converted map interpolation to native HCL2 syntax in eks-worker-nodes.tf
- Updated VPC-related resources tags in vpc.tf:
  - VPC tags
  - Subnet tags
  - Internet Gateway tags

These changes maintain the same tag values while modernizing the syntax to be compatible with newer versions of Terraform.