### PR TITLE
Update Terraform syntax and EKS worker AMI configuration

### DIFF
--- a/cluster/eks-cluster.tf
+++ b/cluster/eks-cluster.tf
@@ -76,8 +76,8 @@ resource "aws_eks_cluster" "demo" {
   role_arn = "${aws_iam_role.demo-cluster.arn}"
 
   vpc_config {
-    security_group_ids = ["${aws_security_group.demo-cluster.id}"]
-    subnet_ids         = ["${aws_subnet.demo.*.id}"]
+    security_group_ids = [aws_security_group.demo-cluster.id]
+    subnet_ids         = aws_subnet.demo[*].id
   }
 
   depends_on = [

--- a/cluster/eks-worker-nodes.tf
+++ b/cluster/eks-worker-nodes.tf
@@ -87,11 +87,10 @@ resource "aws_security_group_rule" "demo-node-ingress-cluster" {
 data "aws_ami" "eks-worker" {
   filter {
     name   = "name"
-    values = ["eks-worker-*"]
+    values = ["amazon-eks-node-${aws_eks_cluster.demo.version}-v*"]
   }
-
   most_recent = true
-  owners      = ["602401143452"] # Amazon
+  owners      = ["602401143452"] # Amazon EKS AMI Account ID
 }
 
 # EKS currently documents this required userdata for EKS worker nodes to


### PR DESCRIPTION
This PR updates the Terraform configuration with modern syntax and improves EKS worker node AMI selection. Changes include:

- Updated deprecated tags syntax from `tags {}` to `tags = {}`
- Removed deprecated string interpolation in list variables
- Updated EKS worker node AMI filter to use dynamic version matching
- Simplified map declarations for kubernetes cluster tags
- Updated security group and subnet ID references to use cleaner syntax

These changes improve maintainability and ensure compatibility with newer EKS worker node AMIs.