### PR TITLE
Update Terraform syntax for tags and list references

### DIFF
--- a/cluster/eks-worker-nodes.tf
+++ b/cluster/eks-worker-nodes.tf
@@ -143,7 +143,7 @@ resource "aws_autoscaling_group" "demo" {
   max_size             = 2
   min_size             = 1
   name                 = "terraform-eks-demo"
-  vpc_zone_identifier  = ["${aws_subnet.demo.*.id}"]
+  vpc_zone_identifier = aws_subnet.demo[*].id
 
   tag {
     key                 = "Name"


### PR DESCRIPTION
This PR updates the Terraform configuration files to use modern syntax for tags and list references. Changes include:

- Replace deprecated `tags` block syntax with new `tags = {}` syntax
- Update list references to use splat expression `[*]` instead of string interpolation
- Convert `map()` function calls to native map syntax
- Standardize tag definitions across EKS cluster resources

These changes improve code readability and ensure compatibility with newer versions of Terraform while maintaining the same functionality.