### PR TITLE
Add Breno worker node group to EKS cluster

### DIFF
--- a/cluster/eks-worker-nodes.tf
+++ b/cluster/eks-worker-nodes.tf
@@ -157,3 +157,106 @@ resource "aws_autoscaling_group" "demo" {
     propagate_at_launch = true
   }
 }
+
+# Add breno node IAM resources
+resource "aws_iam_role" "breno-node" {
+  name = "terraform-eks-breno-node"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_instance_profile" "breno-node" {
+  name = "terraform-eks-breno"
+  role = aws_iam_role.breno-node.name
+}
+
+# Add breno node security group
+resource "aws_security_group" "breno-node" {
+  name        = "terraform-eks-breno-node"
+  description = "Security group for breno nodes in the cluster"
+  vpc_id      = aws_vpc.demo.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "terraform-eks-breno-node"
+    "kubernetes.io/cluster/${var.cluster-name}" = "owned"
+  }
+}
+
+# Add launch configuration and autoscaling group
+resource "aws_launch_configuration" "breno" {
+  associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.breno-node.name
+  image_id                    = data.aws_ami.eks-worker.id
+  instance_type               = "m4.large"
+  name_prefix                 = "terraform-eks-breno"
+  security_groups            = [aws_security_group.breno-node.id]
+  user_data_base64           = base64encode(local.demo-node-userdata)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "breno" {
+  desired_capacity     = 2
+  launch_configuration = aws_launch_configuration.breno.id
+  max_size             = 2
+  min_size             = 1
+  name                 = "terraform-eks-breno"
+  vpc_zone_identifier  = aws_subnet.demo[*].id
+
+  tag {
+    key                 = "Name"
+    value               = "terraform-eks-breno"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kubernetes.io/cluster/${var.cluster-name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+}
+
+  tag {
+    key                 = "Name"
+    value               = "terraform-eks-demo"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kubernetes.io/cluster/${var.cluster-name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+}

--- a/cluster/outputs.tf
+++ b/cluster/outputs.tf
@@ -18,6 +18,11 @@ data:
       groups:
         - system:bootstrappers
         - system:nodes
+    - rolearn: ${aws_iam_role.breno-node.arn}
+      username: system:node:{{EC2PrivateDNSName}}
+      groups:
+        - system:bootstrappers
+        - system:nodes
 CONFIGMAPAWSAUTH
 
   kubeconfig = <<KUBECONFIG

--- a/cluster/security-groups.tf
+++ b/cluster/security-groups.tf
@@ -7,3 +7,33 @@ resource "aws_security_group_rule" "demo-node-ingress-http" {
   type                     = "ingress"
   cidr_blocks              = ["0.0.0.0/0"]
 }
+
+resource "aws_security_group_rule" "breno-node-ingress-http" {
+  description              = "Allow HTTP inbound"
+  from_port                = 80
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.breno-node.id
+  to_port                  = 80
+  type                     = "ingress"
+  cidr_blocks              = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "breno-node-ingress-self" {
+  description              = "Allow node to communicate with each other"
+  from_port                = 0
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.breno-node.id
+  source_security_group_id = aws_security_group.breno-node.id
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "breno-node-ingress-cluster" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
+  from_port                = 1025
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.breno-node.id
+  source_security_group_id = aws_security_group.demo-cluster.id
+  to_port                  = 65535
+  type                     = "ingress"
+}


### PR DESCRIPTION
This PR adds a new worker node group named "breno" to the EKS cluster. Changes include:

- Created IAM role and policies for Breno worker nodes
- Added security group and rules for Breno nodes
- Created launch configuration and autoscaling group for Breno nodes
- Updated config-map-aws-auth to include Breno node role
- Added necessary security group rules for node-to-node and cluster communication

The new node group is configured with:
- Instance type: m4.large
- Desired capacity: 2 nodes
- Auto-scaling limits: min 1, max 2 nodes
- Public IP addressing enabled
- Standard EKS worker node policies and permissions