### PR TITLE
Add Breno worker node group to EKS cluster

### DIFF
--- a/cluster/outputs.tf
+++ b/cluster/outputs.tf
@@ -4,8 +4,6 @@
 
 locals {
   config-map-aws-auth = <<CONFIGMAPAWSAUTH
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,6 +12,11 @@ metadata:
 data:
   mapRoles: |
     - rolearn: ${aws_iam_role.demo-node.arn}
+      username: system:node:{{EC2PrivateDNSName}}
+      groups:
+        - system:bootstrappers
+        - system:nodes
+    - rolearn: ${aws_iam_role.breno-node.arn}
       username: system:node:{{EC2PrivateDNSName}}
       groups:
         - system:bootstrappers


### PR DESCRIPTION
This PR adds a new worker node group named "breno" to the EKS cluster. Changes include:

- Created new IAM role and instance profile for breno nodes
- Added security group for breno node group
- Created launch configuration and autoscaling group for breno nodes
- Updated aws-auth ConfigMap to include the new IAM role mapping

The new node group is configured with:
- Instance type: m4.large
- Desired capacity: 2 nodes
- Min/Max size: 1/2 nodes
- Same VPC and subnet configuration as existing demo nodes