### PR TITLE
Add Breno worker node group to EKS cluster

### DIFF
--- a/cluster/eks-worker-nodes.tf
+++ b/cluster/eks-worker-nodes.tf
@@ -158,6 +158,114 @@ resource "aws_autoscaling_group" "demo" {
   }
 }
 
+resource "aws_iam_role" "breno-node" {
+  name = "terraform-eks-breno-node"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_instance_profile" "breno-node" {
+  name = "terraform-eks-breno"
+  role = aws_iam_role.breno-node.name
+}
+
+resource "aws_security_group" "breno-node" {
+  name        = "terraform-eks-breno-node"
+  description = "Security group for breno nodes in the cluster"
+  vpc_id      = aws_vpc.demo.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "terraform-eks-breno-node"
+    "kubernetes.io/cluster/${var.cluster-name}" = "owned"
+  }
+}
+
+resource "aws_security_group_rule" "breno-node-ingress-self" {
+  description              = "Allow node to communicate with each other"
+  from_port                = 0
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.breno-node.id
+  source_security_group_id = aws_security_group.breno-node.id
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "breno-node-ingress-cluster" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
+  from_port                = 1025
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.breno-node.id
+  source_security_group_id = aws_security_group.demo-cluster.id
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_launch_configuration" "breno" {
+  associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.breno-node.name
+  image_id                    = data.aws_ami.eks-worker.id
+  instance_type               = "m4.large"
+  name_prefix                 = "terraform-eks-breno"
+  security_groups            = [aws_security_group.breno-node.id]
+  user_data_base64           = base64encode(local.demo-node-userdata)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "breno" {
+  desired_capacity     = 2
+  launch_configuration = aws_launch_configuration.breno.id
+  max_size             = 2
+  min_size             = 1
+  name                 = "terraform-eks-breno"
+  vpc_zone_identifier  = aws_subnet.demo[*].id
+
+  tag {
+    key                 = "Name"
+    value               = "terraform-eks-breno"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kubernetes.io/cluster/${var.cluster-name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+}
+
 # Add IAM role for breno node
 resource "aws_iam_role" "breno-node" {
   name = "terraform-eks-breno-node"


### PR DESCRIPTION
This PR adds a new worker node group named "breno" to the EKS cluster with the following changes:

- Created IAM role and instance profile for the new node group
- Added security group and rules for node-to-node and control plane communication
- Created launch configuration and autoscaling group for the new nodes
- Updated aws-auth ConfigMap to include the new node group's IAM role

The new node group is configured with:
- Instance type: m4.large
- Desired capacity: 2 nodes
- Min/Max size: 1/2 nodes
- Public IP addressing enabled
- Same base AMI and user data as existing nodes