### PR TITLE
Add Breno EKS worker node configuration

### DIFF
--- a/cluster/eks-worker-nodes.tf
+++ b/cluster/eks-worker-nodes.tf
@@ -158,6 +158,80 @@ resource "aws_autoscaling_group" "demo" {
   }
 }
 
+resource "aws_iam_role" "breno-node" {
+  name = "terraform-eks-breno-node"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_instance_profile" "breno-node" {
+  name = "terraform-eks-breno"
+  role = aws_iam_role.breno-node.name
+}
+
+resource "aws_launch_configuration" "breno" {
+  associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.breno-node.name
+  image_id                    = data.aws_ami.eks-worker.id
+  instance_type              = "m4.large"
+  name_prefix                = "terraform-eks-breno"
+  security_groups            = [aws_security_group.demo-node.id]
+  user_data_base64          = base64encode(local.demo-node-userdata)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "breno" {
+  desired_capacity     = 2
+  launch_configuration = aws_launch_configuration.breno.id
+  max_size             = 2
+  min_size             = 1
+  name                 = "terraform-eks-breno"
+  vpc_zone_identifier  = aws_subnet.demo[*].id
+
+  tag {
+    key                 = "Name"
+    value               = "terraform-eks-breno"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kubernetes.io/cluster/${var.cluster-name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+}
+
 # Add IAM role for breno node
 resource "aws_iam_role" "breno-node" {
   name = "terraform-eks-breno-node"


### PR DESCRIPTION
This PR adds configuration for a new EKS worker node group named "breno". Changes include:

- Created IAM role and policy attachments for EKS worker nodes
- Added IAM instance profile for EC2 instances
- Configured launch configuration with m4.large instance type
- Set up autoscaling group with desired capacity of 2 nodes

The new worker node group will use the same VPC, security groups, and AMI as the existing demo configuration but with separate IAM permissions and scaling policies.