### PR TITLE
Add Breno worker nodes to EKS cluster

### DIFF
--- a/cluster/eks-worker-nodes.tf
+++ b/cluster/eks-worker-nodes.tf
@@ -84,6 +84,80 @@ resource "aws_security_group_rule" "demo-node-ingress-cluster" {
   type                     = "ingress"
 }
 
+resource "aws_iam_role" "breno-node" {
+  name = "terraform-eks-breno-node"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "breno-node-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.breno-node.name
+}
+
+resource "aws_iam_instance_profile" "breno-node" {
+  name = "terraform-eks-breno"
+  role = aws_iam_role.breno-node.name
+}
+
+resource "aws_launch_configuration" "breno" {
+  associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.breno-node.name
+  image_id                    = data.aws_ami.eks-worker.id
+  instance_type               = "m4.large"
+  name_prefix                 = "terraform-eks-breno"
+  security_groups            = [aws_security_group.demo-node.id]
+  user_data_base64           = base64encode(local.demo-node-userdata)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "breno" {
+  desired_capacity     = 2
+  launch_configuration = aws_launch_configuration.breno.id
+  max_size             = 2
+  min_size             = 1
+  name                 = "terraform-eks-breno"
+  vpc_zone_identifier  = aws_subnet.demo[*].id
+
+  tag {
+    key                 = "Name"
+    value               = "terraform-eks-breno"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kubernetes.io/cluster/${var.cluster-name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+}
+
 data "aws_ami" "eks-worker" {
   filter {
     name   = "name"


### PR DESCRIPTION
This PR adds a new set of worker nodes to the EKS cluster and updates the authentication configuration. Changes include:

- Added new `breno-node` IAM role and associated policy attachments
- Created launch configuration and autoscaling group for new worker nodes
- Updated `config-map-aws-auth` to include the new node role ARN

The new worker nodes will:
- Use m4.large instances
- Maintain 2 desired nodes with autoscaling (min 1, max 2)
- Have the same security groups and base configuration as existing nodes

These changes will increase the cluster's capacity while maintaining proper authentication and access controls.