### PR TITLE
Restructure project as a reusable Terraform module

### DIFF
--- a/examples/basic-eks/main.tf
+++ b/examples/basic-eks/main.tf
@@ -1,0 +1,9 @@
+module "eks" {
+  source = "../../modules/eks"
+  
+  aws_region = var.aws_region
+  cluster_name = var.cluster_name
+  availability_zones = var.availability_zones
+  cluster_endpoint_allowed_cidrs = var.cluster_endpoint_allowed_cidrs
+  map_admin_user_arn = var.map_admin_user_arn
+}

--- a/examples/basic-eks/outputs.tf
+++ b/examples/basic-eks/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_name" {
+  value = module.eks.cluster_name
+}

--- a/examples/basic-eks/variables.tf
+++ b/examples/basic-eks/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  type = string
+  default = "us-east-1"
+}
+
+variable "cluster_name" {
+  type = string
+  default = "demo-eks"
+}
+
+variable "availability_zones" {
+  type = list(string)
+  default = ["us-east-1a", "us-east-1b"]
+}
+
+variable "cluster_endpoint_allowed_cidrs" {
+  type = list(string)
+  default = ["0.0.0.0/0"]
+}
+
+variable "map_admin_user_arn" {
+  type = string
+}


### PR DESCRIPTION
This PR restructures the project as a reusable Terraform module for EKS cluster deployment. Changes include:

### Directory Structure Changes
- Moved EKS-related Terraform files from `cluster/` to `modules/eks/`
- Renamed files to follow consistent naming convention
- Removed `cluster/` and `kubernetes/` directories

### New Features
- Added basic example implementation in `examples/basic-eks/`
- Created module interface with configurable variables
- Added outputs for cluster endpoint and name

### Other Changes
- Updated `.gitignore` to use more specific patterns for Terraform files
- Standardized file naming convention across module files

The restructuring makes the project more maintainable and reusable as a proper Terraform module.