### PR TITLE
Refactor VPC into separate module

### DIFF
--- a/examples/basic-eks/main.tf
+++ b/examples/basic-eks/main.tf
@@ -12,12 +12,20 @@ provider "kubernetes" {
   }
 }
 
-module "eks" {
-  source = "../../modules/eks"
+module "vpc" {
+  source      = "../../modules/vpc"
+  name_prefix = var.cluster_name
+  vpc_cidr    = "10.0.0.0/16"
+  num_azs     = 2
+  tags        = var.tags
+}
 
+module "eks" {
+  source      = "../../modules/eks"
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.public_subnet_ids
   cluster-name        = var.cluster-name
   kubernetes_version  = var.kubernetes_version
-  vpc_cidr           = var.vpc_cidr
   node_instance_type = var.node_instance_type
   node_desired_size  = var.node_desired_size
   node_max_size      = var.node_max_size

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -15,15 +15,14 @@ variable "kubernetes_version" {
   }
 }
 
-variable "vpc_cidr" {
-  description = "CIDR block for VPC"
+variable "vpc_id" {
   type        = string
-  default     = "10.0.0.0/16"
-  
-  validation {
-    condition     = can(cidrhost(var.vpc_cidr, 0))
-    error_message = "Must be valid IPv4 CIDR."
-  }
+  description = "ID of VPC where EKS cluster will be created"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of subnet IDs for EKS cluster"
 }
 
 variable "node_instance_type" {


### PR DESCRIPTION
This PR refactors the VPC-related resources into a separate reusable module. Key changes include:

- Created new `vpc` module with:
  - VPC resource with DNS support
  - Public subnets across multiple AZs
  - Internet Gateway and route tables
  - Kubernetes-specific tags
- Updated EKS module to:
  - Remove VPC-related resources
  - Accept VPC ID and subnet IDs as variables
  - Update security group and cluster subnet references
- Modified example to demonstrate usage of both modules

This change improves modularity and allows VPC resources to be managed independently of the EKS cluster.