### PR TITLE
Add EKS worker node configuration and IAM roles

### DIFF
--- a/modules/eks/templates/userdata.sh
+++ b/modules/eks/templates/userdata.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Configure kubelet
+/etc/eks/bootstrap.sh ${cluster_name}


### PR DESCRIPTION
This PR adds configuration for EKS worker nodes including necessary IAM roles and an updated launch template. Changes include:

- Created `userdata.sh` template for node bootstrapping
- Added AWS AMI data source for EKS worker nodes
- Created IAM role and instance profile for worker nodes with required policies:
  - AmazonEKSWorkerNodePolicy
  - AmazonEC2ContainerRegistryReadOnly
  - AmazonEKS_CNI_Policy
- Updated launch template configuration with:
  - Network interface settings
  - IAM instance profile
  - User data script
  - Proper tagging for EKS cluster integration

These changes provide the necessary infrastructure for EKS worker nodes to join the cluster securely.