### PR TITLE
Refactor EKS module to use existing VPC infrastructure

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,4 +1,30 @@
+# Add IAM role for EKS cluster
+resource "aws_iam_role" "cluster" {
+  name = "${var.cluster-name}-cluster-role"
 
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "eks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSServicePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.cluster.name
+}
 
 # Security Groups
 resource "aws_security_group" "cluster" {
@@ -67,16 +93,10 @@ resource "aws_security_group_rule" "node-ingress-cluster" {
   type                    = "ingress"
 }
 
-
-
-
-
-
 resource "aws_iam_role_policy_attachment" "node-AmazonEKS_CNI_Policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = aws_iam_role.node.name
 }
-
 
 # Add Auto Scaling Group for worker nodes
 resource "aws_autoscaling_group" "node" {
@@ -168,7 +188,6 @@ resource "aws_iam_role_policy_attachment" "node-AmazonEC2ContainerRegistryReadOn
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = aws_iam_role.node.name
 }
-
 
 resource "aws_iam_instance_profile" "node" {
   name = "${var.cluster-name}-node-profile"

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -1,29 +1,15 @@
-output "cluster_id" {
-  description = "The name/id of the EKS cluster"
-  value       = aws_eks_cluster.demo.id
+output "endpoint" {
+  value = aws_eks_cluster.demo.endpoint
 }
 
-output "cluster_endpoint" {
-  description = "The endpoint for your EKS Kubernetes API"
-  value       = aws_eks_cluster.demo.endpoint
+output "kubeconfig-certificate-authority-data" {
+  value = aws_eks_cluster.demo.certificate_authority[0].data
 }
 
-output "cluster_certificate_authority" {
-  description = "Certificate authority data for the cluster"
-  value       = aws_eks_cluster.demo.certificate_authority[0].data
+output "cluster_name" {
+  value = aws_eks_cluster.demo.name
 }
 
-output "worker_security_group_id" {
-  description = "Security group ID attached to the EKS workers"
-  value       = aws_security_group.node.id
-}
-
-output "vpc_id" {
-  description = "ID of the VPC"
-  value       = var.vpc_id
-}
-
-output "subnet_ids" {
-  description = "List of subnet IDs"
-  value       = var.subnet_ids
+output "cluster_security_group_id" {
+  value = aws_security_group.cluster.id
 }

--- a/modules/eks/templates/userdata.sh
+++ b/modules/eks/templates/userdata.sh
@@ -1,5 +1,2 @@
 #!/bin/bash
-set -e
-
-# Configure kubelet
-/etc/eks/bootstrap.sh ${cluster_name}
+/etc/eks/bootstrap.sh ${cluster_name} --kubelet-extra-args "--node-labels=node-type=worker"

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -1,50 +1,31 @@
 variable "cluster-name" {
-  description = "Name of the EKS cluster"
-  type        = string
-  default     = "terraform-eks"
+  type = string
 }
 
 variable "kubernetes_version" {
-  description = "Kubernetes version to use for the EKS cluster"
-  type        = string
-  default     = "1.27"
-  
-  validation {
-    condition     = can(regex("^1\\.(2[3-7]|[3-9][0-9])$", var.kubernetes_version))
-    error_message = "Kubernetes version must be 1.23 or higher."
-  }
+  type = string
 }
 
 variable "vpc_id" {
-  description = "The ID of the VPC where the cluster will be deployed"
-  type        = string
+  type = string
 }
 
 variable "subnet_ids" {
-  description = "List of subnet IDs where the cluster will be deployed"
-  type        = list(string)
+  type = list(string)
 }
 
 variable "node_instance_type" {
-  description = "EC2 instance type for worker nodes"
-  type        = string
-  default     = "t3.medium"
+  type = string
 }
 
 variable "node_desired_size" {
-  description = "Desired number of worker nodes"
-  type        = number
-  default     = 2
+  type = number
 }
 
 variable "node_max_size" {
-  description = "Maximum number of worker nodes"
-  type        = number
-  default     = 4
+  type = number
 }
 
 variable "node_min_size" {
-  description = "Minimum number of worker nodes"
-  type        = number
-  default     = 1
+  type = number
 }


### PR DESCRIPTION
This PR refactors the EKS module to use existing VPC infrastructure instead of creating its own. Key changes include:

- Removed VPC resource creation from the EKS module
- Updated module to accept VPC and subnet IDs as input variables
- Enhanced IAM role configurations for cluster and worker nodes
- Improved launch template configuration with network interfaces
- Simplified variables.tf by removing defaults and validations
- Streamlined outputs.tf to focus on essential cluster information
- Added userdata.sh template for worker node bootstrapping

The changes make the module more reusable by separating concerns between networking and EKS cluster management.