### PR TITLE
Update EKS subnet configuration to use public subnets

### DIFF
--- a/examples/basic-eks/main.tf
+++ b/examples/basic-eks/main.tf
@@ -23,7 +23,7 @@ module "eks" {
   cluster-name = var.cluster-name
   kubernetes_version = var.kubernetes_version
   vpc_id = module.vpc.vpc_id
-  subnet_ids = module.vpc.subnet_ids
+  subnet_ids = module.vpc.public_subnet_ids
   node_instance_type = var.node_instance_type
   node_desired_size = var.node_desired_size
   node_max_size = var.node_max_size

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -103,7 +103,7 @@ resource "aws_eks_cluster" "demo" {
 
   vpc_config {
     security_group_ids = [aws_security_group.cluster.id]
-    subnet_ids         = aws_subnet.demo[*].id
+    subnet_ids         = var.subnet_ids
   }
 
   depends_on = [


### PR DESCRIPTION
This PR updates the EKS cluster subnet configuration to use public subnets instead of creating dedicated subnets. Changes include:

- Modified `examples/basic-eks/main.tf` to use `public_subnet_ids` from the VPC module
- Updated `modules/eks/main.tf` to use the provided subnet IDs instead of creating new subnets

This change simplifies the EKS cluster deployment by utilizing existing public subnets from the VPC module rather than creating dedicated subnets within the EKS module.