### PR TITLE
Migrate from Kubernetes manifests to Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ LoadBalancer service configuration
 AWS IAM authentication integration
 Last updated: October 2023 (Terraform 1.5+, AWS Provider 5.0+)
 
+## Deploying with Helm
+
+To deploy the nginx service using Helm:
+
+1. Configure kubectl to use the EKS cluster:
+```bash
+aws eks update-kubeconfig --region us-east-1 --name cc-eks
+```
+
+2. Install the Helm chart:
+```bash
+helm install my-release ./helm --namespace demo-service --create-namespace
+```
+
 
 This README:
 1. Accurately reflects current module structures and relationships

--- a/main.tf
+++ b/main.tf
@@ -2,15 +2,6 @@ provider "aws" {
   region = "us-east-1"
 }
 
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority)
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["eks", "get-token", "--cluster-name", var.cluster-name]
-    command     = "aws"
-  }
-}
 
 module "vpc" {
   source          = "./modules/vpc"


### PR DESCRIPTION
This PR replaces the direct Kubernetes manifests with a Helm chart for managing the nginx deployment. Changes include:

- Removed the `kubernetes/` directory containing raw manifests
- Removed the Kubernetes provider block from `main.tf`
- Added new `helm/` directory with:
  - Chart configuration (`Chart.yaml`)
  - Default values (`values.yaml`)
  - Templated Kubernetes manifests for:
    - Namespace
    - Deployment
    - Service
- Updated README.md with Helm deployment instructions

The Helm chart provides a more maintainable and configurable way to manage the nginx deployment with support for:
- Configurable namespace creation
- Customizable deployment parameters
- LoadBalancer service configuration
- Template-based resource generation