### PR TITLE
Add Helm chart for Nginx deployment

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: simple-nginx
+description: A Helm chart for deploying a simple Nginx service on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app: {{ .Values.deployment.labels.app }}
+spec:
+  replicas: {{ .Values.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Values.deployment.labels.app }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.deployment.labels.app }}
+    spec:
+      containers:
+        - name: {{ .Values.deployment.name }}
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.namespace.create -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}
+  labels:
+    name: {{ .Values.namespace.name }}-label
+  annotations:
+    name: {{ .Values.namespace.name }}-annotation
+{{- end -}}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app: {{ .Values.deployment.labels.app }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Values.deployment.labels.app }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,19 @@
+namespace:
+  name: demo-service
+  create: true
+
+deployment:
+  name: demo-service-nginx
+  replicaCount: 1
+  image:
+    repository: nginx
+    tag: latest
+    pullPolicy: IfNotPresent
+  labels:
+    app: nginx
+
+service:
+  name: demo-service-nginx
+  type: LoadBalancer
+  port: 8080
+  targetPort: 80


### PR DESCRIPTION
This PR adds a new Helm chart configuration for deploying a simple Nginx service on Kubernetes. The changes include:

### Added Files
- `helm/Chart.yaml` - Basic chart metadata and version information
- `helm/values.yaml` - Configurable values for the deployment
- `helm/templates/namespace.yaml` - Template for creating a dedicated namespace
- `helm/templates/deployment.yaml` - Template for Nginx deployment configuration
- `helm/templates/service.yaml` - Template for LoadBalancer service configuration

### Key Features
- Configurable namespace creation
- Nginx deployment with customizable replica count and image settings
- LoadBalancer service exposing port 8080
- Templated resources with values-based configuration

The existing `kubernetes/` directory remains unchanged while introducing this Helm-based deployment option.