### PR TITLE
Add ECR module and integrate with infrastructure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,21 @@
+module "eks" {
+  source = "./modules/eks"
+  cluster-name = var.cluster-name
+  kubernetes_version = var.kubernetes_version
+  vpc_id = module.vpc.vpc_id
+  subnet_ids = module.vpc.public_subnet_ids
+  node_instance_type = var.node_instance_type
+  node_desired_size = var.node_desired_size
+  node_max_size = var.node_max_size
+  node_min_size = var.node_min_size
+}
+
+module "ecr" {
+  source = "./modules/ecr"
+
+  repository_name = "demo-service"
+  tags = {
+    Environment = "dev"
+    Project     = "simple-eks"
+  }
+}

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,10 @@
+resource "aws_ecr_repository" "ecr_repo" {
+  name                 = var.repository_name
+  image_tag_mutability = var.image_tag_mutability ? "MUTABLE" : "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_images_on_push
+  }
+
+  tags = var.tags
+}

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,14 @@
+output "repository_url" {
+  description = "The URL of the ECR repository."
+  value       = aws_ecr_repository.ecr_repo.repository_url
+}
+
+output "repository_arn" {
+  description = "The ARN of the ECR repository."
+  value       = aws_ecr_repository.ecr_repo.arn
+}
+
+output "repository_name" {
+  description = "The name of the ECR repository."
+  value       = aws_ecr_repository.ecr_repo.name
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,22 @@
+variable "repository_name" {
+  description = "The name of the ECR repository."
+  type        = string
+}
+
+variable "image_tag_mutability" {
+  description = "Sets the image tag mutability setting for the repository. If true, tags are mutable; if false, tags are immutable."
+  type        = bool
+  default     = false
+}
+
+variable "scan_images_on_push" {
+  description = "Indicates whether images are scanned after being pushed to the repository."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the ECR repository."
+  type        = map(string)
+  default     = {}
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_certificate_authority" {
+  description = "Base64 encoded certificate data required to communicate with cluster"
+  value       = module.eks.cluster_certificate_authority
+}
+
+output "ecr_repository_url" {
+  description = "The URL of the ECR repository"
+  value       = module.ecr.repository_url
+}
+
+output "ecr_repository_arn" {
+  description = "The ARN of the ECR repository"
+  value       = module.ecr.repository_arn
+}


### PR DESCRIPTION
This PR adds a new ECR (Elastic Container Registry) module to the infrastructure and configures it for the demo-service. Changes include:

- Created new ECR module with:
  - Configurable repository name
  - Image tag mutability settings
  - Image scanning on push capability
  - Custom tags support
- Added ECR module to main infrastructure with:
  - Repository name set to "demo-service"
  - Environment and Project tags
- Added new outputs to expose:
  - ECR repository URL
  - ECR repository ARN

The ECR repository will be used to store container images for the demo service with automatic security scanning enabled by default.